### PR TITLE
Remove trade specialists

### DIFF
--- a/common/districts/pd_habitat_districts.txt
+++ b/common/districts/pd_habitat_districts.txt
@@ -1684,16 +1684,6 @@ district_pdhab_commercial = {
 				is_fallen_empire_spiritualist = no 
 			}
 		}
-		text = job_tec_trade_specialist_effect_desc
-	}
-
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = { 
-				is_fallen_empire_spiritualist = no 
-			}
-		}
 		text = job_clerk_effect_desc
 	}
 


### PR DESCRIPTION
Ok, so this does actually seem to work. I'm still not sure why. I'm still not sure why it didn't at first. I'm going to assume that this change had gotten overridden by the irony mod manager when I tested it the first time.